### PR TITLE
[ksk] 결재 승인,반려 기능 완료2_20250423

### DIFF
--- a/eroom/src/main/java/com/eroom/approval/controller/ApprovalController.java
+++ b/eroom/src/main/java/com/eroom/approval/controller/ApprovalController.java
@@ -413,17 +413,22 @@ public class ApprovalController {
 					List<ApprovalLine> temp = approval.getApprovalLines();
 					Boolean bool = false;
 					Boolean stackBool = false;
+					int count = 0;
 					// step이 0인 사람(합의자) 중 결재 상태가 A인 사람이 한명이라도 있으면 stackBool = false처리
 					for(int i = 0; i < temp.size(); i++) {
 						if(temp.get(i).getApprovalLineStep() != 0) {
 							continue;
 						}
-						if(temp.get(i).getApprovalLineStep() == 0 && !temp.get(i).getApprovalLineStatus().equals("A")) {
-							stackBool = false;
-							break;
-						} else if(temp.get(i).getApprovalLineStep() == 0 && temp.get(i).getApprovalLineStatus().equals("A")) {
-							stackBool = true;
+						if(temp.get(i).getApprovalLineStep() == 0) {
+							count++;
+							if(!temp.get(i).getApprovalLineStatus().equals("A")) {
+								stackBool = false;
+								break;
+							} else if(temp.get(i).getApprovalLineStatus().equals("A")) {
+								stackBool = true;
+							}
 						}
+						
 						
 				    }
 					// 결재 라인에 있는 사람들 중~
@@ -443,9 +448,16 @@ public class ApprovalController {
 							}
 						}
 						// 모든 합의자가 status = A, 나의 결재 차례인 경우에만 approval을 담아서 보내기
-						if(bool && stackBool && !approval.getApprovalStatus().equals("F")) {
-							temp2 = approvalService.selectApprovalByApprovalNo(temp.get(i).getApproval().getApprovalNo());
-							resultApprovalList.add(temp2);
+						if(count == 0) {
+							if(bool && !approval.getApprovalStatus().equals("F")) {
+								temp2 = approvalService.selectApprovalByApprovalNo(temp.get(i).getApproval().getApprovalNo());
+								resultApprovalList.add(temp2);
+							}
+						} else {
+							if(bool && stackBool && !approval.getApprovalStatus().equals("F")) {
+								temp2 = approvalService.selectApprovalByApprovalNo(temp.get(i).getApproval().getApprovalNo());
+								resultApprovalList.add(temp2);
+							}
 						}
 					}
 				}

--- a/eroom/src/main/resources/templates/approval/detail.html
+++ b/eroom/src/main/resources/templates/approval/detail.html
@@ -180,7 +180,7 @@
 	<!-- 회수 버튼 -->
 	<script th:inline="javascript">
 	
-		document.getElementByClassName("fallBackBtn").addEventListener("click", function(){
+		document.getElementById("fallBackBtn").addEventListener("click", function(){
 			const fallBackNo = /*[[${approval.approval_no}]]*/ 0;
 			if(confirm('결재를 회수하시겠습니까?')){
 				fetch('/approval/' + fallBackNo + '/fallBack',{


### PR DESCRIPTION
	- 회수시 내가 올린 결재, 회수한 결재 페이지에서만 조회 가능
	- 회수한 결재 페이지 작성 완료
	- 회수한 결재 nav url, html 변경 (withdrawnApprovals -> fallBackApprovals)
	- 상세 페이지 참조자 표기 오류 수정
	- 관리자 로그인시 요청한 결재 페이지에서 삭제된 결재를 제외한 모든 결재 확인 가능
	- 자신의 결재 차례에만 결재,반려 버튼 출력
	- 내가 받은 결재 로직 수정
	- (기존 : 합의자 1명만 합의해도 1번 결재자에게 결재글이 보임)
	- (수정 : 모든 합의자가 합의한 후에 1번 결재자에게 결재글이 보이게 수정)
	- 결재 승인, 반려 기능 완료
	- (결재 중 반려시 결재 상태에 반려 반영, 최종 결재자 결재 승인시 결재 상태에 결재 승인 완료 반영)
	- 오류 수정(반려 버튼 수정)