### PR TITLE
[ksk] 결재자, 합의자, 참조자 웹소켓 알림 기능 완료_20250428

### DIFF
--- a/eroom/src/main/java/com/eroom/approval/controller/ApprovalController.java
+++ b/eroom/src/main/java/com/eroom/approval/controller/ApprovalController.java
@@ -29,6 +29,7 @@ import com.eroom.approval.dto.ApprovalFormatDto;
 import com.eroom.approval.dto.ApprovalLineDto;
 import com.eroom.approval.dto.ApprovalRequestDto;
 import com.eroom.approval.entity.Approval;
+import com.eroom.approval.entity.ApprovalAlarm;
 import com.eroom.approval.entity.ApprovalFormat;
 import com.eroom.approval.entity.ApprovalLine;
 import com.eroom.approval.service.ApprovalFormatService;
@@ -43,6 +44,7 @@ import com.eroom.employee.entity.Structure;
 import com.eroom.employee.service.EmployeeService;
 import com.eroom.employee.service.StructureService;
 import com.eroom.security.EmployeeDetails;
+import com.eroom.websocket.ApprovalWebSocketHandler;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -62,6 +64,7 @@ public class ApprovalController {
 	private final StructureService structureService;
 	private final EmployeeService employeeService;
 	private final DriveService driveService;
+	private final ApprovalWebSocketHandler approvalWebSocketHandler;
 	
 	
 	// 내가 올린 결재 리스트 조회
@@ -542,7 +545,7 @@ public class ApprovalController {
 					Boolean bool = false;
 					Boolean stackBool = false;
 					int count = 0;
-					// step이 0인 사람(합의자) 중 결재 상태가 A인 사람이 한명이라도 있으면 stackBool = false처리
+					// step이 0인 사람(합의자) 중 결재 상태가 A 아닌 사람이 한명이라도 있으면 stackBool = false처리
 					for(int i = 0; i < temp.size(); i++) {
 						if(temp.get(i).getApprovalLineStep() != 0) {
 							continue;

--- a/eroom/src/main/java/com/eroom/approval/repository/ApprovalLineRepository.java
+++ b/eroom/src/main/java/com/eroom/approval/repository/ApprovalLineRepository.java
@@ -16,7 +16,14 @@ public interface ApprovalLineRepository extends JpaRepository<ApprovalLine, Long
 
 	// 회원 번호로 결재 라인 조회
 	List<ApprovalLine> findApprovalLinesByEmployee_EmployeeNo(Long employeeNo);
-
+	
 	ApprovalLine findByApproval_ApprovalNoAndEmployee_EmployeeNo(Long approvalNo, Long employeeNo);
+	
+	@Query("SELECT a FROM ApprovalLine a JOIN FETCH a.employee WHERE a.approval.approvalNo = :approvalNo AND a.approvalLineStep >= 1")
+	List<ApprovalLine> findApprovalLinesByStepGreaterThanEqualOne(@Param("approvalNo") Long approvalNo);
+	
+	@Query("SELECT a FROM ApprovalLine a JOIN FETCH a.employee WHERE a.approval.approvalNo = :approvalNo AND a.approvalLineStep = 0")
+	List<ApprovalLine> findApprovalLinesByStepEqualZero(@Param("approvalNo") Long approvalNo);
+
 
 }

--- a/eroom/src/main/java/com/eroom/approval/service/ApprovalAlarmService.java
+++ b/eroom/src/main/java/com/eroom/approval/service/ApprovalAlarmService.java
@@ -38,4 +38,5 @@ public class ApprovalAlarmService {
 		}
 		return result;
 	}
+
 }

--- a/eroom/src/main/java/com/eroom/approval/service/ApprovalLineService.java
+++ b/eroom/src/main/java/com/eroom/approval/service/ApprovalLineService.java
@@ -11,6 +11,7 @@ import com.eroom.approval.entity.ApprovalLine;
 import com.eroom.approval.repository.ApprovalLineRepository;
 import com.eroom.approval.repository.ApprovalRepository;
 import com.eroom.employee.service.EmployeeService;
+import com.eroom.websocket.ApprovalWebSocketHandler;
 
 import lombok.RequiredArgsConstructor;
 
@@ -21,6 +22,7 @@ public class ApprovalLineService {
 	private final ApprovalLineRepository approvalLineRepository;
 	private final ApprovalRepository approvalRepository;
 	private final EmployeeService employeeService;
+	private final ApprovalWebSocketHandler approvalWebSocketHandler;
 	
 	// 결재 번호로 결재 라인 조회
 	public List<ApprovalLine> getApprovalLineByApprovalNo(Long approvalNo) {
@@ -52,14 +54,46 @@ public class ApprovalLineService {
 			ApprovalLine appLine = approvalLineRepository.findByApproval_ApprovalNoAndEmployee_EmployeeNo(approvalNo, employeeNo);
 //			System.out.println("결재 번호 : " + appLine.getApproval().getApprovalNo());
 //			System.out.println("로그인한 직원번호 나와야함 : " + employeeNo);
-			appLine.setApprovalLineSignedDate(LocalDateTime.now());
+//			appLine.setApprovalLineSignedDate(LocalDateTime.now());
 			appLine.setApprovalLineStatus(approvalLine.getApprovalLineStatus());
 //			System.out.println("이거이거 A 맞아?" + appLine.getApprovalLineStatus());
 			if (appLine != null) {
 				appLine.setApprovalLineStatus(approvalLine.getApprovalLineStatus());
 				approvalLineRepository.save(appLine);
-				result = 1;
+				
+				// 여기서 웹소켓 등장! 알림용
+				// 내 다음 사람이 있으면 알림 주기
+				List<ApprovalLine> appLineZeroList = approvalLineRepository.findApprovalLinesByStepEqualZero(approvalNo);
+				List<ApprovalLine> appLineOverOneList = approvalLineRepository.findApprovalLinesByStepGreaterThanEqualOne(approvalNo);
+				// 합의자 전부 승인A 했다면 결재자 반복문 돌려서 웹소켓 알림 띄우고 break 그런데 appLineZeroList 사이즈가 0이면 반복 돌리지 않음.
+				int isAllAgree = 0;
+				for(ApprovalLine appLineZero : appLineZeroList) {
+					if(appLineZero.getApprovalLineStatus().equals("A")) {
+						isAllAgree++;
+					}
+				}
+				
+				if(isAllAgree == appLineZeroList.size() && !appLineOverOneList.isEmpty()) {
+					// 합의자 전부 합의A 했다면~ + 결재자가 있다면~
+					// 그 외 조건들은 앞에서 이미 걸러짐
+//					for(ApprovalLine appLineOne : appLineOverOneList) {
+//						if(appLineOne.getApprovalLineStatus().equals("S")) {
+//							// 웹소켓 입장
+//							String message = "[결재] 결재 요청이 도착했습니다. 승인 또는 반려해주세요.";
+//							approvalWebSocketHandler.sendApprovalNotification(appLineOne.getEmployee().getEmployeeNo(), message, appLineOne.getApproval());
+//							break;
+//						}
+//					}
+					approvalLineOverOneListAndWebSocketHandler(appLineOverOneList);
+				} else if(appLineZeroList.isEmpty() && !appLineOverOneList.isEmpty()) {
+					approvalLineOverOneListAndWebSocketHandler(appLineOverOneList);
+				}
+				
+				
+				
+				
 			}
+			result = 1;
 		} catch (Exception e) {
 			e.printStackTrace();
 			result = -1;
@@ -80,6 +114,15 @@ public class ApprovalLineService {
 		return isMyLineApproval;
 	}
 
-	
+	private void approvalLineOverOneListAndWebSocketHandler(List<ApprovalLine> appLineOverOneList) {
+		for(ApprovalLine appLineOne : appLineOverOneList) {
+			if(appLineOne.getApprovalLineStatus().equals("S")) {
+				// 웹소켓 입장
+				String message = "[결재] 결재 요청이 도착했습니다. 승인 또는 반려해주세요.";
+				approvalWebSocketHandler.sendApprovalNotification(appLineOne.getEmployee().getEmployeeNo(), message, appLineOne.getApproval());
+				break;
+			}
+		}
+	}
 	
 }

--- a/eroom/src/main/java/com/eroom/approval/service/ApprovalService.java
+++ b/eroom/src/main/java/com/eroom/approval/service/ApprovalService.java
@@ -164,6 +164,12 @@ public class ApprovalService {
 						.approvalLineStep(dto.getApproverSteps().get(i)) // 결재자 순서 step 1,2,3...
 						.build();
 					approvalLineRepository.save(approvalLine);
+					if(dto.getAgreerIds().isEmpty() && i == 0) {
+						message = "[결재] 결재 요청이 도착했습니다. 승인 또는 반려해주세요.";
+				        if(approvalResultNo != null) {
+				        	approvalWebSocketHandler.sendApprovalNotification(dto.getApproverIds().get(i), message, approvalResult);
+				        }
+					}
 			}
 			
 			
@@ -255,9 +261,9 @@ public class ApprovalService {
 					String message = "";
 					// 웹소켓 알림 기능. 기안자의 EmployeeNo를 보내준다.
 					if(endApproval.getApprovalStatus().equals("A")) {
-						message = approval.getApprovalFormat().getApprovalFormatTitle() + "의 결재가 완료 되었습니다!";
+						message = "[결재] " + approval.getApprovalFormat().getApprovalFormatTitle() + "의 결재가 완료 되었습니다!";
 					} else if(endApproval.getApprovalStatus().equals("D")) {
-						message = approval.getApprovalFormat().getApprovalFormatTitle() + "의 결재가 반려 되었습니다!";
+						message = "[결재] " + approval.getApprovalFormat().getApprovalFormatTitle() + "의 결재가 반려 되었습니다!";
 					}
 			        approvalWebSocketHandler.sendApprovalNotification(endApproval.getEmployee().getEmployeeNo(), message, endApproval);
 					// 연차 관련 결재인가 판단

--- a/eroom/src/main/java/com/eroom/approval/service/ApprovalService.java
+++ b/eroom/src/main/java/com/eroom/approval/service/ApprovalService.java
@@ -270,7 +270,6 @@ public class ApprovalService {
 								CompanyCalendarDto companyCalendarDto = CompanyCalendarDto.builder()
 										.employee_no(approvalEmployee.getEmployeeNo())
 										.company_creator(approvalEmployee.getEmployeeId())
-										.company_location("-")
 										.separator("A001")
 										.visibleYn("Y")
 										.build();

--- a/eroom/src/main/java/com/eroom/drive/service/DriveService.java
+++ b/eroom/src/main/java/com/eroom/drive/service/DriveService.java
@@ -179,7 +179,7 @@ public class DriveService {
 		        String ext = oriName.substring(oriName.lastIndexOf("."));
 		        String newName = UUID.randomUUID().toString().replace("-", "") + ext;
 
-		        String path = fileDir + "personal/" + newName;
+		        String path = fileDir + "approval/" + newName;
 		        File savedFile = new File(path);
 		        if (!savedFile.getParentFile().exists()) {
 		            savedFile.getParentFile().mkdirs();
@@ -212,7 +212,7 @@ public class DriveService {
 	// ------------------------- 결재 파일 리스트 조회 --------------------------
 	// 결재 번호(param1)로 조회
 	public List<DriveDto> findApprovalDriveFiles(Long param1) {
-	    List<Drive> drives = driveRepository.findByParam1AndVisibleYnAndSeparatorCode(param1, "N", "Fl007");
+	    List<Drive> drives = driveRepository.findByParam1AndVisibleYnAndSeparatorCode(param1, "Y", "Fl007");
 	    List<DriveDto> result = new ArrayList<>();
 
 	    for (Drive drive : drives) {
@@ -226,7 +226,7 @@ public class DriveService {
 		int result = 0;
 		try {
 			for(Long l : approvalAttachFileIds) {
-				Drive oldDrive = driveRepository.findByDriveAttachNoAndVisibleYnAndSeparatorCode(l, "N", "FL007");
+				Drive oldDrive = driveRepository.findByDriveAttachNoAndVisibleYnAndSeparatorCode(l, "Y", "FL007");
 				// 영속성 없는 객체 생성
 	            Drive newDrive = new Drive();
 	            

--- a/eroom/src/main/java/com/eroom/websocket/ApprovalWebSocketHandler.java
+++ b/eroom/src/main/java/com/eroom/websocket/ApprovalWebSocketHandler.java
@@ -52,23 +52,23 @@ public class ApprovalWebSocketHandler extends TextWebSocketHandler {
     }
 
     // ApprovalService에서 호출할 메소드
-    public void sendApprovalNotification(Long approvalCreatorEmployeeNo, String message, Approval endApproval) {
-        WebSocketSession session = sessions.get(approvalCreatorEmployeeNo);
-        saveNotificationToDatabase(approvalCreatorEmployeeNo, message, endApproval);
+    public void sendApprovalNotification(Long receiverNo, String message, Approval approval) {
+        WebSocketSession session = sessions.get(receiverNo);
 
         if (session != null && session.isOpen()) {
             try {
+            	saveNotificationToDatabase(receiverNo, message, approval);
                 session.sendMessage(new TextMessage(message));
-                log.info("알림 전송 성공: employeeNo={}", approvalCreatorEmployeeNo);
+                log.info("알림 전송 성공: employeeNo={}", receiverNo);
             } catch (Exception e) {
-                log.error("알림 전송 실패: employeeNo=" + approvalCreatorEmployeeNo, e);
+                log.error("알림 전송 실패: employeeNo=" + receiverNo, e);
             }
         } else {
-            log.warn("알림 전송 실패: 세션이 존재하지 않거나 닫힘. employeeNo={}", approvalCreatorEmployeeNo);
+            log.warn("알림 전송 실패: 세션이 존재하지 않거나 닫힘. employeeNo={}", receiverNo);
         }
     }
     
-    private void saveNotificationToDatabase(Long approvalCreatorEmployeeNo, String message, Approval endApproval) {
-    	approvalAlarmService.alarmSaveMethod(approvalCreatorEmployeeNo, message, endApproval);
+    private void saveNotificationToDatabase(Long receiverNo, String message, Approval approval) {
+    	approvalAlarmService.alarmSaveMethod(receiverNo, message, approval);
     }
 }

--- a/eroom/src/main/java/com/eroom/websocket/ApprovalWebSocketHandler.java
+++ b/eroom/src/main/java/com/eroom/websocket/ApprovalWebSocketHandler.java
@@ -9,6 +9,7 @@ import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
 import com.eroom.approval.entity.Approval;
+import com.eroom.approval.entity.ApprovalAlarm;
 import com.eroom.approval.service.ApprovalAlarmService;
 
 import lombok.RequiredArgsConstructor;
@@ -68,6 +69,7 @@ public class ApprovalWebSocketHandler extends TextWebSocketHandler {
         }
     }
     
+    // 알람 저장용
     private void saveNotificationToDatabase(Long receiverNo, String message, Approval approval) {
     	approvalAlarmService.alarmSaveMethod(receiverNo, message, approval);
     }

--- a/eroom/src/main/resources/templates/approval/create.html
+++ b/eroom/src/main/resources/templates/approval/create.html
@@ -65,7 +65,7 @@
 									<button type="button" class="btn-close btn-close-white position-absolute top-0 end-0" th:attr="data-idx=${stat.count}"
 										aria-label="Remove" style="scale: 0.8;">
 									</button>
-									<input type="hidden" name="approverIds" th:value="${approveMember.employee.employeeNo}"> <input type="hidden" name="approverSteps" th:value="${stat.count}">
+									<input type="hidden" name="approverIds" th:value="${approveMember.employee.employeeNo}"> <input type="hidden" name="approverSteps" th:value="${approveMember.approval_line_step}">
 								</div>
 							</div>
 						</div>


### PR DESCRIPTION
[ksk] 결재자, 합의자, 참조자 웹소켓 알림 기능 완료_20250428

	- 웹소켓 연결 완료(layout) 오류 코드 제거
	- 오류 코드 수정 완료
	- (임시 : approval 관련 페이지만 웹소켓 동작 확인 완료.)
	- (임시 : 다른 페이지 접속 가능하게 수정 완료.)
	- 연차 관련 결재시 location "-" -> null 처리
	- (calendar.html에서 빈 값은 출력 없음)
	- 합의자, 참조자 웹소켓 알림 기능 완료.
	- (결재 등록시 합의자, 참조자에게 웹소켓 알림)
	- 결재 순번에 따른 알람 기능 완료.