### PR TITLE
[ksk] 결재 백엔드 로직 수정 완료, 홈화면 결재 파트 완료_20250510

### DIFF
--- a/eroom/src/main/java/com/eroom/SchedulerConfig.java
+++ b/eroom/src/main/java/com/eroom/SchedulerConfig.java
@@ -34,5 +34,12 @@ public class SchedulerConfig {
 	    LocalDateTime limitDate = LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusDays(15);
 	    mailStatusRepository.updateVisibilityOfOldTrash(limitDate);
 	}
-	
+	@Scheduled(cron = "0 0 0 1 1 *", zone = "Asia/Seoul")
+	public void runEveryYear() {
+	    // System.out.println("새해 첫날 실행됨!");
+	}
+	@Scheduled(cron = "0 0 0 1 * *", zone = "Asia/Seoul")
+	public void runEveryMonth() {
+	    // System.out.println("매달 1일 00시에 실행됨!");
+	}
  }

--- a/eroom/src/main/java/com/eroom/approval/dto/ApprovalDto.java
+++ b/eroom/src/main/java/com/eroom/approval/dto/ApprovalDto.java
@@ -35,6 +35,7 @@ public class ApprovalDto {
     private String completed_date; // 완료일 (String)
     
     private Employee employee; // 기안자
+    private String employee_name; // 기안자
     private ApprovalFormat approval_format; // 결재 양식
     private String approval_visible_yn; // 결재 사용여부
     

--- a/eroom/src/main/java/com/eroom/approval/repository/ApprovalRepository.java
+++ b/eroom/src/main/java/com/eroom/approval/repository/ApprovalRepository.java
@@ -15,9 +15,17 @@ public interface ApprovalRepository extends JpaRepository<Approval, Long> {
 
 	List<Approval> findAllByApprovalVisibleYn(String string);
 
-	// 마이페이지 사용. 내가 올린 결재 중 진행상태와 visible 매개변수로 사용.
+	// mainpage Approval 리스트 조회1
 	List<Approval> findByEmployee_EmployeeNoAndApprovalStatusAndApprovalVisibleYnOrderByApprovalRegDateDesc(Long employeeNo,
 			String approvalStatus, String approvalVisibleYn);
+	// 마이페이지용 결재 불러오기
+	List<Approval> findTop5ByApprovalStatusAndApprovalVisibleYnAndEmployee_EmployeeNoOrderByApprovalRegDateDesc(String approvalStatus, String approvalVisibleYn, Long employeeNo);
+	// mainpage Approval 리스트 조회3
+	List<Approval> findTop5ByApprovalStatusInAndApprovalVisibleYnAndEmployee_EmployeeNoOrderByApprovalRegDateDesc(
+		    List<String> approvalStatuses, String approvalVisibleYn, Long employeeNo
+		);
+
+
 
 
 	

--- a/eroom/src/main/java/com/eroom/approval/service/ApprovalService.java
+++ b/eroom/src/main/java/com/eroom/approval/service/ApprovalService.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -475,7 +476,7 @@ public class ApprovalService {
 	
 	// 마이페이지, 내 결재 조회 - 진행중
 	public List<ApprovalDto> myPageMyApprovalsStatusIsS(Long employeeNo) {
-		List<Approval> list =  approvalRepository.findByEmployee_EmployeeNoAndApprovalStatusAndApprovalVisibleYnOrderByApprovalRegDateDesc(employeeNo, "S", "Y");
+		List<Approval> list =  approvalRepository.findTop5ByApprovalStatusAndApprovalVisibleYnAndEmployee_EmployeeNoOrderByApprovalRegDateDesc("S", "Y", employeeNo);
 		List<ApprovalDto> resultList = new ArrayList<ApprovalDto>();
 		for(Approval a : list) {
 			ApprovalDto dto = new ApprovalDto().toDto(a);
@@ -485,6 +486,27 @@ public class ApprovalService {
 		int limit = Math.min(resultList.size(), 5);
 		return resultList.subList(0, limit);
 	}
+	
+	// mainpage Approval 리스트 조회1
+	public List<Approval> getOngoingApprovals(Long employeeNo) {
+	    return approvalRepository.findTop5ByApprovalStatusAndApprovalVisibleYnAndEmployee_EmployeeNoOrderByApprovalRegDateDesc("S", "Y", employeeNo);
+	}
+
+	// mainpage Approval 리스트 조회2
+	public List<Approval> getPendingApprovals(Long employeeNo) {
+		// 내가 합의나 결재 순번인 경우 가져와야하니 ApprovalLineService에 접근해보자.
+	    //return approvalRepository.findTop5ByStatusOrderByCreatedDateDesc("PENDING");
+		return null;
+	}
+
+	// mainpage Approval 리스트 조회3
+	public List<Approval> getCompletedApprovals(Long employeeNo) {
+		List<String> statuses = Arrays.asList("A", "D");
+	    return approvalRepository.findTop5ByApprovalStatusInAndApprovalVisibleYnAndEmployee_EmployeeNoOrderByApprovalRegDateDesc(statuses, "Y", employeeNo);
+	}
+
+	
+	
 
 
 

--- a/eroom/src/main/java/com/eroom/home/controller/HomeController.java
+++ b/eroom/src/main/java/com/eroom/home/controller/HomeController.java
@@ -1,9 +1,11 @@
 package com.eroom.home.controller;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -11,6 +13,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import com.eroom.approval.dto.ApprovalDto;
+import com.eroom.approval.dto.ApprovalLineDto;
+import com.eroom.approval.entity.Approval;
+import com.eroom.approval.entity.ApprovalLine;
+import com.eroom.approval.service.ApprovalLineService;
+import com.eroom.approval.service.ApprovalService;
 import com.eroom.attendance.dto.AttendanceDto;
 import com.eroom.attendance.entity.Attendance;
 import com.eroom.attendance.service.AttendanceService;
@@ -30,6 +38,8 @@ public class HomeController {
 	private final AttendanceService attendanceService;
 	private final VehicleService vehicleService;
 	private final MeetingRoomService meetingRoomService;
+	private final ApprovalService approvalService;
+	private final ApprovalLineService approvalLineService;
 
 	@GetMapping({"", "/"})
 	public String home(Model model, Authentication authentication) {
@@ -74,6 +84,173 @@ public class HomeController {
 		
 		return resultMap;
 	}
+	
+	// 내가 올린 진행중인 결재
+	@GetMapping("/mainpage/approval/ongoing")
+	@ResponseBody
+	public List<Map<String, Object>> getOngoingApprovals(Authentication authentication) {
+	    EmployeeDetails employee = (EmployeeDetails) authentication.getPrincipal();
+	    List<ApprovalDto> dtoList = new ArrayList<ApprovalDto>();
+	    List<Approval> list = approvalService.getOngoingApprovals(employee.getEmployee().getEmployeeNo());
+	    for(Approval l : list) {
+	    	dtoList.add(new ApprovalDto().toDto(l));
+	    }
+	    
+	    List<Map<String, Object>> resultList = new ArrayList<>();
+	    for (ApprovalDto dto : dtoList) {
+	        Map<String, Object> map = new HashMap<>();
+	        map.put("approval_no", dto.getApproval_no());
+	        map.put("approval_title", dto.getApproval_title());
+	        map.put("approval_display_date", dto.getReg_date());
+	        map.put("approval_completed_date", dto.getCompleted_date());
+	        map.put("approval_status", dto.getApproval_status());
+	        map.put("approval_toMe", false);
+	        resultList.add(map);
+	    }
+	    return resultList;
+	}
+	// 내가 결재 또는 합의 해야하는 결재
+	@GetMapping("/mainpage/approval/pending")
+	@ResponseBody
+	public List<Map<String, Object>> getPendingApprovals(Authentication authentication) {
+	    EmployeeDetails employee = (EmployeeDetails) authentication.getPrincipal();
+	    Long employeeNo = employee.getEmployeeNo();
+	    List<ApprovalLine> var1Entity = approvalLineService.getApprovalLineByEmployeeNo(employeeNo);
+		Map<Long, List<ApprovalLineDto>> var1Map = new HashMap<Long, List<ApprovalLineDto>>();
+		Approval temp2 = null;
+		List<Approval> resultApprovalList = new ArrayList<Approval>();
+		List<ApprovalDto> resultApprovalListDto = new ArrayList<ApprovalDto>();
+
+		for (ApprovalLine a : var1Entity) {
+			if(!a.getApprovalLineStatus().equals("S")) {
+				continue;
+			}
+			
+			
+			// 결재라인용 - 내가 결재 라인에 있는 approval들의 결재번호로 approval 리스트 조회
+			List<Approval> approvalList = approvalService.getApprovalListByApprovalNo(a.getApproval().getApprovalNo(), "Y");
+			if (approvalList != null) {
+				// 결재라인용 - 결재라인에 있는 결재번호로 approval 리스트 entity -> Dto 변환
+				for (Approval approval : approvalList) {
+					List<ApprovalLine> var1 = approvalLineService.getApprovalLineByApprovalNo(approval.getApprovalNo());
+					List<ApprovalLineDto> tempDtoList = new ArrayList<>();
+				    for(int i = 0; i < var1.size(); i++) {
+				    	tempDtoList.add(new ApprovalLineDto().toDto(var1.get(i)));
+				    }
+				    var1Map.put(approval.getApprovalNo(), tempDtoList);
+					
+				    // 결재 리스트옹 - 내가 해당 결재의 현재 순번이 맞는 결재들만 보내기
+					List<ApprovalLine> temp = approval.getApprovalLines();
+					Boolean bool = false;
+					Boolean stackBool = false;
+					int count = 0;
+					// step이 0인 사람(합의자) 중 결재 상태가 A 아닌 사람이 한명이라도 있으면 stackBool = false처리
+					for(int i = 0; i < temp.size(); i++) {
+						if(temp.get(i).getApprovalLineStep() != 0) {
+							continue;
+						}
+						if(temp.get(i).getApprovalLineStep() == 0) {
+							count++;
+							// 내가 합의인 경우 추가 - home
+							if(temp.get(i).getEmployee().getEmployeeNo() == employeeNo && temp.get(i).getApprovalLineStatus().equals("S")) {
+								temp2 = approvalService.selectApprovalByApprovalNo(temp.get(i).getApproval().getApprovalNo());
+								resultApprovalList.add(temp2);
+							}
+							if(!temp.get(i).getApprovalLineStatus().equals("A")) {
+								stackBool = false;
+								break;
+							} else if(temp.get(i).getApprovalLineStatus().equals("A")) {
+								stackBool = true;
+							}
+						}
+						
+						
+				    }
+					
+					
+					// 결재 라인에 있는 사람들 중~
+					for(int i = 0; i < temp.size(); i++) {
+						bool = false;
+						// 내가 결재 라인!
+						if(temp.get(i).getApprovalLineStep() >= 1) {
+							// 나보다 앞에서 결재 하는 사람의 status확인
+							if (i > 0) {
+								if(temp.get(i - 1).getApprovalLineStatus().equals("A") && temp.get(i).getEmployee().getEmployeeNo() == employeeNo) {
+									bool = true;
+								}
+							// 내가 제일 처음 결재자인 경우
+							} else if (i == 0) {
+								if(temp.get(i).getEmployee().getEmployeeNo() == employeeNo) {
+									bool = true;
+								}
+							}
+						}
+						
+						
+						
+						// 모든 합의자가 status = A, 나의 결재 차례 이후인 경우에만 approval을 담아서 보내기
+						if(count == 0) {
+							if(bool && !approval.getApprovalStatus().equals("F")) {
+								temp2 = approvalService.selectApprovalByApprovalNo(temp.get(i).getApproval().getApprovalNo());
+								resultApprovalList.add(temp2);
+							}
+						} else {
+							if(bool && stackBool && !approval.getApprovalStatus().equals("F")) {
+								temp2 = approvalService.selectApprovalByApprovalNo(temp.get(i).getApproval().getApprovalNo());
+								resultApprovalList.add(temp2);
+							}
+						}
+					}
+				}
+			}
+		}
+		resultApprovalList.sort((a1, a2) -> a2.getApprovalRegDate().compareTo(a1.getApprovalRegDate()));
+		for (Approval t : resultApprovalList) {
+			ApprovalDto dto = new ApprovalDto();
+			dto = dto.toDto(t);
+			dto.setEmployee_name(t.getEmployee().getEmployeeName());
+			resultApprovalListDto.add(dto);
+		}
+		// - home
+	    List<Map<String, Object>> resultList = new ArrayList<>();
+	    for (ApprovalDto dto : resultApprovalListDto) {
+	    		Map<String, Object> map = new HashMap<>();
+	    		map.put("approval_no", dto.getApproval_no());
+	    		map.put("approval_title", dto.getApproval_title());
+	    		map.put("approval_display_date", dto.getReg_date());
+	    		map.put("approval_completed_date", dto.getCompleted_date());
+	    		map.put("approval_status", dto.getApproval_status());
+	    		map.put("approval_toMe", true);
+	    		map.put("approval_writer", dto.getEmployee().getEmployeeName());
+	    		resultList.add(map);
+	    }
+	    return resultList;
+	}
+	// 내가 올린 승인, 반려 처리 된 결재
+	@GetMapping("/mainpage/approval/completed")
+	@ResponseBody
+	public List<Map<String, Object>> getCompletedApprovals(Authentication authentication) {
+	    EmployeeDetails employee = (EmployeeDetails) authentication.getPrincipal();
+	    List<ApprovalDto> dtoList = new ArrayList<ApprovalDto>();
+	    List<Approval> list = approvalService.getCompletedApprovals(employee.getEmployee().getEmployeeNo());
+	    for(Approval l : list) {
+	    	dtoList.add(new ApprovalDto().toDto(l));
+	    }
+	    
+	    List<Map<String, Object>> resultList = new ArrayList<>();
+	    for (ApprovalDto dto : dtoList) {
+	        Map<String, Object> map = new HashMap<>();
+	        map.put("approval_no", dto.getApproval_no());
+	        map.put("approval_title", dto.getApproval_title());
+	        map.put("approval_display_date", dto.getReg_date());
+	        map.put("approval_completed_date", dto.getCompleted_date());
+	        map.put("approval_status", dto.getApproval_status());
+	        map.put("approval_toMe", false);
+	        resultList.add(map);
+	    }
+	    return resultList;
+	}
+	
 	
 
 }

--- a/eroom/src/main/resources/templates/index.html
+++ b/eroom/src/main/resources/templates/index.html
@@ -150,7 +150,39 @@
   text-overflow: ellipsis;
 }
 
+/* 결재 관련 스타일 태그 */
+.bg-primary-soft {
+  background-color: rgba(13, 110, 253, 0.1); /* Bootstrap primary with 투명도 */
+}
+.bg-success-soft {
+  background-color: rgba(25, 135, 84, 0.1); /* Bootstrap success with 투명도 */
+}
+.bg-fail-soft {
+  background-color: rgba(253, 175, 171, 0.5); /* 50% 투명도 적용 */
+}
+.bg-warning-soft {
+    background-color: rgba(255, 193, 7, 0.1); /* Bootstrap Warning 색상에 투명도 적용 */
+}
 
+
+.carousel-indicators {
+  bottom: -26px; /* ✅ 기본보다 아래로 내림 */
+  justify-content: center; /* ✅ 가운데 정렬 (기본) */
+} 
+
+.carousel-indicators [data-bs-target] {
+  width: 10px;
+  height: 3px;
+/*   background-color: rgba(13, 110, 253, 0.5); */ /* 반투명 primary */
+  background-color: rgba(108, 117, 125, 0.5); /* secondary 반투명 */  
+  border: none;
+}
+
+.carousel-indicators .active {
+ /*  background-color: #0d6efd; */ /* 활성화된 점 */
+  background-color: #6c757d; /* secondary 진한 색 */  
+}
+/* 결재 관련 스타일 태그 */
 	
   </style>
 </head>
@@ -205,12 +237,131 @@
           </div>
         </div>
 
-        <!-- 1행·2열 -->
+        <!-- 1행·2열 결재 -->
         <div class="text-white p-1">
 			<div class="attendance-card mx-auto">
 				<div class="card shadow-sm border-0">
 					<div class="card-body text-center p-4" style="height: 207.81px;">
-						결재<br>(요청한, 대기(요청받은), 승인 / 개수)
+						
+
+	
+
+<!-- Tab 메뉴 -->
+<div class="d-flex justify-content-between align-items-center mb-2">
+  <div class="fw-bold text-dark" style="font-size: 0.9rem;">결재</div>
+  <ul class="nav nav-underline fs-9" id="resTab" role="tablist" style="margin-bottom: 0;">
+    <li class="nav-item" role="presentation">
+      <a class="nav-link active" id="approvalPending-tab" data-bs-toggle="tab" href="#approvalPendingTab"
+         role="tab" aria-controls="approvalPendingTab" aria-selected="true">내게 온 결재</a>
+    </li>
+    <li class="nav-item" role="presentation">
+      <a class="nav-link" id="approvalOngoing-tab" data-bs-toggle="tab" href="#approvalOngoingTab"
+         role="tab" aria-controls="approvalOngoingTab" aria-selected="false">진행 중 결재</a>
+    </li>
+    <li class="nav-item" role="presentation">
+      <a class="nav-link" id="approvalCompleted-tab" data-bs-toggle="tab" href="#approvalCompletedTab"
+         role="tab" aria-controls="approvalCompletedTab" aria-selected="false">완료된 결재</a>
+    </li>
+  </ul>
+</div>
+
+<!-- 탭 내용 -->
+<div class="tab-content">
+
+  <!-- 승인/반려 대기 -->
+  <div class="tab-pane fade show active" id="approvalPendingTab">
+    <div class="carousel slide" id="approvalPendingCarousel">
+
+      <!-- ✅ 인디케이터 -->
+      <div class="carousel-indicators" id="pendingCarouselIndicators">
+        <!-- JavaScript에서 동적 로딩 -->
+      </div>
+
+      <!-- ✅ 슬라이드 항목 -->
+      <div class="carousel-inner px-4 text-center" id="pendingCarouselInner">
+        <!-- JavaScript에서 동적 로딩 -->
+      </div>
+
+      <!-- ✅ 이전/다음 버튼 -->
+      <button class="position-absolute border-0 bg-transparent text-secondary"
+        type="button" data-bs-target="#approvalPendingCarousel" data-bs-slide="prev"
+        style="top: 65%; left: -10px; transform: translateY(-50%); z-index: 2;">
+        <i class="fas fa-chevron-left fs-7"></i>
+      </button>
+      <button class="position-absolute border-0 bg-transparent text-secondary"
+              type="button" data-bs-target="#approvalPendingCarousel" data-bs-slide="next"
+              style="top: 65%; right: -10px; transform: translateY(-50%); z-index: 2;">
+        <i class="fas fa-chevron-right fs-7"></i>
+      </button>
+
+    </div>
+  </div>
+
+  <!-- 진행 중 결재 -->
+  <div class="tab-pane fade" id="approvalOngoingTab">
+    <div class="carousel slide" id="approvalOngoingCarousel">
+
+      <!-- ✅ 인디케이터 -->
+      <div class="carousel-indicators" id="ongoingCarouselIndicators">
+        <!-- JavaScript에서 동적 로딩 -->
+      </div>
+
+      <!-- ✅ 슬라이드 항목 -->
+      <div class="carousel-inner px-4 text-center" id="ongoingCarouselInner">
+        <!-- JavaScript에서 동적 로딩 -->
+      </div>
+
+      <!-- ✅ 이전/다음 버튼 -->
+      <button class="position-absolute border-0 bg-transparent text-secondary"
+        type="button" data-bs-target="#approvalOngoingCarousel" data-bs-slide="prev"
+        style="top: 65%; left: -10px; transform: translateY(-50%); z-index: 2;">
+        <i class="fas fa-chevron-left fs-7"></i>
+      </button>
+      <button class="position-absolute border-0 bg-transparent text-secondary"
+              type="button" data-bs-target="#approvalOngoingCarousel" data-bs-slide="next"
+              style="top: 65%; right: -10px; transform: translateY(-50%); z-index: 2;">
+        <i class="fas fa-chevron-right fs-7"></i>
+      </button>
+
+    </div>
+  </div>
+
+
+  <!-- 승인된 결재 -->
+  <div class="tab-pane fade" id="approvalCompletedTab">
+    <div class="carousel slide" id="approvalCompletedCarousel">
+
+      <!-- ✅ 인디케이터 -->
+      <div class="carousel-indicators" id="completedCarouselIndicators">
+        <!-- JavaScript에서 동적 로딩 -->
+      </div>
+
+      <!-- ✅ 슬라이드 항목 -->
+      <div class="carousel-inner px-4 text-center" id="completedCarouselInner">
+        <!-- JavaScript에서 동적 로딩 -->
+      </div>
+
+      <!-- ✅ 이전/다음 버튼 -->
+      <button class="position-absolute border-0 bg-transparent text-secondary"
+        type="button" data-bs-target="#approvalCompletedCarousel" data-bs-slide="prev"
+        style="top: 65%; left: -10px; transform: translateY(-50%); z-index: 2;">
+        <i class="fas fa-chevron-left fs-7"></i>
+      </button>
+      <button class="position-absolute border-0 bg-transparent text-secondary"
+              type="button" data-bs-target="#approvalCompletedCarousel" data-bs-slide="next"
+              style="top: 65%; right: -10px; transform: translateY(-50%); z-index: 2;">
+        <i class="fas fa-chevron-right fs-7"></i>
+      </button>
+
+    </div>
+  </div>
+
+</div>
+
+				        
+				        
+				        
+				        
 					</div>
 				</div>
 			</div>
@@ -778,7 +929,9 @@
    <script>
    let currentPage = 1;  // 현재 페이지를 추적
    const totalNews = 10; // 전체 뉴스 개수 (예시로 10개 뉴스 항목 사용)
-
+	
+   if(false){
+	   
    function loadNews() {
        fetch('/api/news?query=IT&language=ko&page=' + currentPage + '&size=1')  // IT 뉴스 1개만 가져오기
            .then(response => response.json())
@@ -813,7 +966,212 @@
 
    // 3초마다 뉴스가 넘어가도록 설정
    setInterval(loadNews, 3000);  // 5초마다 loadNews 실행
+   }
 </script>
+<!-- 결재 관련 비동기 -->
+<script>
+//탭 요소들 가져오기
+const approvalOngoingTab = document.getElementById('approvalOngoingInner');
+const approvalPendingTab = document.getElementById('approvalPendingInner');
+const approvalCompletedTab = document.getElementById('approvalCompletedInner');
+
+
+//✅ Carousel 로딩 함수
+async function loadApprovalCarousel(target, endpoint, indicators) {
+    try {
+        const res = await fetch(endpoint);
+        if (!res.ok) throw new Error('서버 오류: ' + res.status);
+
+        const data = await res.json();
+        console.log(`✅ ${endpoint} 응답 결과:`, data);
+
+        // ✅ 초기화
+        target.innerHTML = '';
+        indicators.innerHTML = '';
+
+        if (!data || !Array.isArray(data) || data.length === 0) {
+        	nothingHtmlFormS = `
+                <div class="carousel-item active">
+            	<div class="text-center mb-2">
+				<svg style="height: 12px;" class="svg-inline--fa fa-circle fs-10 text-primary me-1" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" data-fa-i2svg=""><path fill="currentColor" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"></path></svg><!-- <i class="fas fa-circle fs-10 text-primary me-1"></i> Font Awesome fontawesome.com -->
+				<span class="fw-bold fs-9">진행 중인 결재</span>
+			</div>
+                    <div class="border rounded p-3 bg-primary-soft cursor-pointer">
+                        <h5 class="mb-1 fw-bold text-dark text-decoration-none">
+                          진행중인 결재가 없습니다.
+                        </h5>
+                    </div>
+                </div>
+            `;
+        	nothingHtmlFormToMe = `
+                <div class="carousel-item active">
+            	<div class="text-center mb-2">
+            	<svg style="height: 12px;" class="svg-inline--fa fa-circle fs-10 mt-n1" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" data-fa-i2svg="" ><path fill="#FFD700" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"></path></svg><!-- <i class="fas fa-circle fs-10 text-success mt-n1"></i> Font Awesome fontawesome.com -->
+				<span class="fw-bold fs-9">내게 온 결재</span>
+			</div>
+                    <div class="border rounded p-3 bg-warning-soft cursor-pointer">
+                        <h5 class="mb-1 fw-bold text-dark text-decoration-none">
+                        	내게 온 결재가 없습니다.
+                        </h5>
+                    </div>
+                </div>
+            `;
+        	nothingHtmlFormAD = `
+                <div class="carousel-item active">
+            	<div class="text-center mb-2">
+            	<svg style="height: 12px;" class="svg-inline--fa fa-circle fs-10 text-success mt-n1" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" data-fa-i2svg=""><path fill="currentColor" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"></path></svg><!-- <i class="fas fa-circle fs-10 text-success mt-n1"></i> Font Awesome fontawesome.com -->
+            	<svg style="height: 12px;" class="svg-inline--fa fa-circle fs-10 text-danger mt-n1" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" data-fa-i2svg=""><path fill="currentColor" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"></path></svg><!-- <i class="fas fa-circle fs-10 text-success mt-n1"></i> Font Awesome fontawesome.com -->
+				<span class="fw-bold fs-9">완료된 결재</span>
+			</div>
+                    <div class="border rounded p-3 bg-success-soft cursor-pointer">
+                        <h5 class="mb-1 fw-bold text-dark text-decoration-none">
+                        	완료된 결재가 없습니다.
+                        </h5>
+                    </div>
+                </div>
+            `;
+            
+            
+
+			if(endpoint == '/mainpage/approval/ongoing'){
+				target.innerHTML += nothingHtmlFormS
+			} else if(endpoint == '/mainpage/approval/pending'){
+				target.innerHTML += nothingHtmlFormToMe
+			} else if(endpoint == '/mainpage/approval/completed'){
+				target.innerHTML += nothingHtmlFormAD
+			} 
+            return;
+        }
+
+        // ✅ 슬라이드 생성
+        data.forEach((item, index) => {
+            const approvalTitle = item.approval_title ?? '제목 없음';
+            const approvalNo = item.approval_no ?? 0;
+            const displayDate = item.approval_display_date ?? '-';
+            const completedDate = item.approval_completed_date ?? '-';
+			const approvalStatus = item.approval_status ?? '-';
+			const approvalWriter = item.approval_writer ?? '-';
+            // 슬라이드 항목 
+            const htmlFormS = `
+                <div class="carousel-item ${index === 0 ? 'active' : ''}">
+            	<div class="text-center mb-2">
+				<svg style="height: 12px;" class="svg-inline--fa fa-circle fs-10 text-primary me-1" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" data-fa-i2svg=""><path fill="currentColor" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"></path></svg><!-- <i class="fas fa-circle fs-10 text-primary me-1"></i> Font Awesome fontawesome.com -->
+				<span class="fw-bold fs-9">진행 중인 결재</span>
+			</div>
+                    <div class="border rounded p-3 bg-primary-soft cursor-pointer"
+                        onclick="location.href='/approval/${approvalNo}/detail'">
+                        <h5 class="mb-1 fw-bold text-dark text-decoration-none">
+                          ${approvalTitle}
+                        </h5>
+                        <p class="mb-0 text-muted fs-9">기안일 : ${displayDate}</p>
+                    </div>
+                </div>
+            `;
+            const htmlFormA = `
+                <div class="carousel-item ${index === 0 ? 'active' : ''}">
+            	<div class="text-center mb-2">
+				<svg style="height: 12px;" class="svg-inline--fa fa-circle fs-10 text-success mt-n1" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" data-fa-i2svg=""><path fill="currentColor" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"></path></svg><!-- <i class="fas fa-circle fs-10 text-success mt-n1"></i> Font Awesome fontawesome.com -->
+				<span class="fw-bold fs-9">승인된 결재</span>
+			</div>
+                    <div class="border rounded p-3 bg-success-soft cursor-pointer"
+                        onclick="location.href='/approval/${approvalNo}/detail'">
+                        <h5 class="mb-1 fw-bold text-dark text-decoration-none">
+                          ${approvalTitle}
+                        </h5>
+                        <p class="mb-0 text-muted fs-9">완료일 : ${completedDate}</p>
+                    </div>
+                </div>
+            `;
+            const htmlFormD = `
+                <div class="carousel-item ${index === 0 ? 'active' : ''}">
+            	<div class="text-center mb-2">
+            	<svg style="height: 12px;" class="svg-inline--fa fa-circle fs-10 text-danger mt-n1" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" data-fa-i2svg=""><path fill="currentColor" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"></path></svg><!-- <i class="fas fa-circle fs-10 text-success mt-n1"></i> Font Awesome fontawesome.com -->
+				<span class="fw-bold fs-9">반려된 결재</span>
+			</div>
+                    <div class="border rounded p-3 bg-fail-soft cursor-pointer"
+                        onclick="location.href='/approval/${approvalNo}/detail'">
+                        <h5 class="mb-1 fw-bold text-dark text-decoration-none">
+                          ${approvalTitle}
+                        </h5>
+                        <p class="mb-0 text-muted fs-9">완료일 : ${completedDate}</p>
+                    </div>
+                </div>
+            `;
+            const htmlFormToMe = `
+                <div class="carousel-item ${index === 0 ? 'active' : ''}">
+            	<div class="text-center mb-2">
+            	<svg style="height: 12px;" class="svg-inline--fa fa-circle fs-10 mt-n1" aria-hidden="true" focusable="false" data-prefix="fas" data-icon="circle" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" data-fa-i2svg="" ><path fill="#FFD700" d="M256 512A256 256 0 1 0 256 0a256 256 0 1 0 0 512z"></path></svg><!-- <i class="fas fa-circle fs-10 text-success mt-n1"></i> Font Awesome fontawesome.com -->
+				<span class="fw-bold fs-9">내게 온 결재</span>
+			</div>
+                    <div class="border rounded p-3 bg-warning-soft cursor-pointer"
+                        onclick="location.href='/approval/${approvalNo}/detail'">
+                        <h5 class="mb-1 fw-bold text-dark text-decoration-none">
+                          ${approvalTitle}
+                        </h5>
+                        <p class="mb-0 text-muted fs-9">기안자 : ${approvalWriter}</p>
+                        <p class="mb-0 text-muted fs-9">기안일 : ${displayDate}</p>
+                    </div>
+                </div>
+            `;
+			/* if (approvalStatus === 'S') {
+			    if (approval_toMe) {
+			        target.innerHTML += htmlFormToMe;
+			    } else {
+			        target.innerHTML += htmlFormS;
+			    }
+			} else if (approvalStatus === 'A') {
+			    target.innerHTML += htmlFormA;
+			} else if (approvalStatus === 'D') {
+			    target.innerHTML += htmlFormD;
+			} */
+			if(endpoint == '/mainpage/approval/ongoing'){
+				target.innerHTML += htmlFormS
+			} else if(endpoint == '/mainpage/approval/pending'){
+				target.innerHTML += htmlFormToMe
+			} else if(endpoint == '/mainpage/approval/completed'){
+				if(approvalStatus === 'A'){
+					target.innerHTML += htmlFormA
+				} else if(approvalStatus === 'D'){
+					target.innerHTML += htmlFormD
+				}
+			} 
+
+            // 인디케이터 생성
+            indicators.innerHTML += `
+                <button type="button" data-bs-target="#${target.id}" data-bs-slide-to="${index}"
+                        class="${index === 0 ? 'active' : ''}" aria-label="슬라이드 ${index + 1}"></button>
+            `;
+            
+            
+            
+        });
+        
+
+    } catch (error) {
+        console.error(`❌ ${endpoint} 데이터 로딩 오류:`, error);
+    }
+}
+
+// ✅ 로딩 실행
+loadApprovalCarousel(
+    document.getElementById('ongoingCarouselInner'), 
+    '/mainpage/approval/ongoing', 
+    document.getElementById('ongoingCarouselIndicators')
+);
+
+loadApprovalCarousel(
+    document.getElementById('pendingCarouselInner'), 
+    '/mainpage/approval/pending', 
+    document.getElementById('pendingCarouselIndicators')
+);
+
+loadApprovalCarousel(
+    document.getElementById('completedCarouselInner'), 
+    '/mainpage/approval/completed', 
+    document.getElementById('completedCarouselIndicators')
+);
+</script>
+
 
     
 


### PR DESCRIPTION
[ksk] 결재 백엔드 로직 수정 완료, 홈화면 결재 파트 완료_20250510

	- 참조자 선택시 로직 수정
	- (기존:사원만 선택 -> 수정:부서,팀,사원 선택 가능)
	- 결재 상세 페이지 pdf 버튼 수정
	- 홈화면 결재 파트 완료
	- 내게 온 결재, 진행 중 결재, 완료된 결재(승인, 반려) 로 분류
	- 슬라이드 카드 형식(자동 넘기기 제거)
	- 클릭시 해당 상세 페이지 이동