### PR TITLE
[cya] 연차 스케줄러 적용 작업중

### DIFF
--- a/eroom/src/main/java/com/eroom/SchedulerConfig.java
+++ b/eroom/src/main/java/com/eroom/SchedulerConfig.java
@@ -3,11 +3,15 @@ package com.eroom;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.List;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 
+import com.eroom.attendance.service.AnnualLeaveService;
+import com.eroom.employee.entity.Employee;
+import com.eroom.employee.service.EmployeeService;
 import com.eroom.mail.repository.MailStatusRepository;
 import com.eroom.project.repository.ProjectRepository;
 
@@ -20,6 +24,8 @@ public class SchedulerConfig {
 	
 	private final ProjectRepository projectRepository;
 	private final MailStatusRepository mailStatusRepository;
+	private final EmployeeService employeeService;
+	private final AnnualLeaveService annualLeaveService;
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void updateProjectProceed() {
 		
@@ -41,5 +47,18 @@ public class SchedulerConfig {
 	@Scheduled(cron = "0 0 0 1 * *", zone = "Asia/Seoul")
 	public void runEveryMonth() {
 	    // System.out.println("매달 1일 00시에 실행됨!");
+	}
+	// 연차부여
+	@Scheduled(cron = "0 13 1 12 5 *", zone = "Asia/Seoul") // 테스트용 : 5월 12일 
+	public void grantAnnualLeaveToAllEmployees() {
+		// 현재 연도 가져오기
+		Long currentYear = Long.valueOf(LocalDate.now(ZoneId.of("Asia/Seoul")).getYear());
+		// 전체 사원 목록 조회
+		List<Employee> employeeList = employeeService.findAllEmployee();
+		for(Employee employee : employeeList) {
+			Long employeeNo = employee.getEmployeeNo();
+			annualLeaveService.grantAnnualLeave(employeeNo, currentYear);
+		}
+		System.out.println("[연차 스케줄러] "+currentYear + "년도 연차가 부여되었습니다.");
 	}
  }

--- a/eroom/src/main/java/com/eroom/admin/controller/AdminController.java
+++ b/eroom/src/main/java/com/eroom/admin/controller/AdminController.java
@@ -25,6 +25,7 @@ import com.eroom.attendance.dto.AttendanceDto;
 import com.eroom.attendance.entity.AnnualLeave;
 import com.eroom.attendance.service.AnnualLeaveService;
 import com.eroom.attendance.service.AttendanceService;
+import com.eroom.common.AnnualPolicyUtil;
 import com.eroom.directory.dto.DirectoryDto;
 import com.eroom.directory.entity.Directory;
 import com.eroom.directory.service.DirectoryService;
@@ -62,6 +63,7 @@ public class AdminController {
 	private final MeetingRoomService meetingRoomService;
 	private final VehicleService vehicleService;
 	private final AnnualLeaveService annualLeaveService;
+	private final AnnualPolicyUtil annualPolicyUtil;
 	
 	// 회의실 목록
 	@GetMapping("/meetingroom")
@@ -453,8 +455,11 @@ public class AdminController {
 				}
 			}
 			
-			AnnualLeave annualLeave = attendanceService.selectAnnualLeaveByEmployeeNo(employee.getEmployeeNo());
-			
+			// 현재 년도
+			//Long currentYear = Long.valueOf(LocalDate.now().getYear());
+			// 기준일 기반 연차 연도 계산
+	        Long targetYear = annualPolicyUtil.getTargetYearByPolicy();
+			AnnualLeave annualLeave = annualLeaveService.selectAnnualLeaveByEmployeeNoAndYear(employee.getEmployeeNo(),targetYear);
 			// 연차 정보 조회
 			AnnualLeaveDto annualLeaveDto = null;
 			if(annualLeave != null) {
@@ -536,9 +541,13 @@ public class AdminController {
 			DirectoryDto directoryDto = new DirectoryDto().toDto(directory);
 			model.addAttribute("directory", directoryDto);
 		}
-
+		// 현재 년도
+		//Long currentYear = Long.valueOf(LocalDate.now().getYear());
+		// 기준일 기반 연차 연도 계산
+        Long targetYear = annualPolicyUtil.getTargetYearByPolicy();
 		// 연차 정보 조회
-		AnnualLeave annualLeave = attendanceService.selectAnnualLeaveByEmployeeNo(employeeNo);
+		//AnnualLeave annualLeave = attendanceService.selectAnnualLeaveByEmployeeNo(employeeNo);
+		AnnualLeave annualLeave = annualLeaveService.selectAnnualLeaveByEmployeeNoAndYear(employeeNo,targetYear);
 		AnnualLeaveDto annualLeaveDto;
 		if (annualLeave != null) {
 			annualLeaveDto = new AnnualLeaveDto().toDto(annualLeave);

--- a/eroom/src/main/java/com/eroom/attendance/controller/AttendanceController.java
+++ b/eroom/src/main/java/com/eroom/attendance/controller/AttendanceController.java
@@ -37,98 +37,98 @@ public class AttendanceController {
 	private final StructureService structureService;
 	private final DirectoryService employeeDirectoryService;
 	
-	// 근태 페이지 목록
-	@GetMapping("/list")
-	public String selectAttendanceList(@RequestParam(name= "month",required = false) String month,Model model, Authentication authentication) {
-		// 로그인한 사용자 정보
-		EmployeeDetails employeeDetail = (EmployeeDetails) authentication.getPrincipal();
-		Employee employee = employeeDetail.getEmployee();
-		Long employeeNo = employee.getEmployeeNo();
-		model.addAttribute("employee", employee);
-		
-		Structure employeeStructure = employee.getStructure();  
-		String departmentName = "-"; // 기본값
-		// 부서 정보 조회
-		if(employeeStructure != null) {
-			// 부서 정보가 있을 경우에만 parentCode를 사용하여 부서명 조회
-			String parentCode = employeeStructure.getParentCode();
-			Structure structure = structureService.selectStructureCodeNameByParentCodeEqualsSeparatorCode(parentCode);
-			if(structure != null) {
-				departmentName = structure.getCodeName();
-			} else {
-				// 부서 정보가 없을 경우 기본값 사용
-				departmentName = "-";
-			}
-		}
-        model.addAttribute("departmentName", departmentName);
-        
-        // 주소록 정보 조회
-        Directory directory = employeeDirectoryService.selectDirectoryByEmployeeNo(employeeNo);
-//        System.out.println("directory 정보 : " + directory);
-        if(directory != null) {
-        	DirectoryDto directoryDto = new DirectoryDto().toDto(directory);
-        	model.addAttribute("directory", directoryDto);
-        }
-        
-        
-        // 연차 정보 조회
-        AnnualLeave annualLeave = attendanceService.selectAnnualLeaveByEmployeeNo(employeeNo);
-        AnnualLeaveDto annualLeaveDto;
-        if (annualLeave != null) {
-        	annualLeaveDto = new AnnualLeaveDto().toDto(annualLeave);
-		}else {
-			annualLeaveDto = new AnnualLeaveDto();
-			annualLeaveDto.setAnnual_leave_total(0.0);
-			annualLeaveDto.setAnnual_leave_used(0.0);
-			annualLeaveDto.setAnnual_leave_remain(0.0);
-		}
-        model.addAttribute("annualLeave",annualLeaveDto);
-        
-		// 근태 기록이 있는 월 목록 조회
-		List<String> monthList = attendanceService.selectAttendanceMonthList(employeeNo);
-		
-		// 현재 년월 가져오기
-		String currentMonth = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy.MM"));
-		
-		// 현재 월이 목록에 포함되어 있다면 맨 위로 정렬
-		if(monthList.contains(currentMonth)) {
-			monthList.remove(currentMonth); // 중복 제거
-			monthList.add(0, currentMonth); // 맨 앞에 삽입
-		}
-		
-		model.addAttribute("monthList", monthList);
-		
-		// selectedMonth -> 사용자가 선택한 월이 없으면 현재 월이 기본값
-		String selectedMonth = (month != null && !month.isEmpty()) ? month : currentMonth;
-		model.addAttribute("selectedMonth",selectedMonth);
-		// 해당 월의 근태 기록 조회
-		List<AttendanceDto> attendanceList = attendanceService.selectAttendanceListByMonth(employeeNo, selectedMonth);
-		model.addAttribute("attendanceList",attendanceList);
-		
-		// 근태 차트 요약 데이터
-		Map<String, Object> chartData = attendanceService.getAttendanceChartData(employeeDetail);
-		// 근무시간 문자열만 가져오기
-		String totalWorkTime = (String) chartData.get("totalWorkTime");
-		model.addAttribute("totalWorkTime", totalWorkTime);
-		
-		// 근태요약 정보 가져오기
-		Map<String,Object> summaryData = attendanceService.getAttendanceChartData(employeeDetail);
-		model.addAttribute("summaryData", summaryData);
-		
-		return "attendance/list";
-	}
-	
-	@GetMapping("/chartData")
-	@ResponseBody
-	public Map<String,Object> getChartData(){
-		// 현재 로그인 정보
-		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-		EmployeeDetails employeeDetail = (EmployeeDetails)authentication.getPrincipal();
-		
-		// 차트 데이터
-		return attendanceService.getAttendanceChartData(employeeDetail);
-		
-	}
+//	// 근태 페이지 목록
+//	@GetMapping("/list")
+//	public String selectAttendanceList(@RequestParam(name= "month",required = false) String month,Model model, Authentication authentication) {
+//		// 로그인한 사용자 정보
+//		EmployeeDetails employeeDetail = (EmployeeDetails) authentication.getPrincipal();
+//		Employee employee = employeeDetail.getEmployee();
+//		Long employeeNo = employee.getEmployeeNo();
+//		model.addAttribute("employee", employee);
+//		
+//		Structure employeeStructure = employee.getStructure();  
+//		String departmentName = "-"; // 기본값
+//		// 부서 정보 조회
+//		if(employeeStructure != null) {
+//			// 부서 정보가 있을 경우에만 parentCode를 사용하여 부서명 조회
+//			String parentCode = employeeStructure.getParentCode();
+//			Structure structure = structureService.selectStructureCodeNameByParentCodeEqualsSeparatorCode(parentCode);
+//			if(structure != null) {
+//				departmentName = structure.getCodeName();
+//			} else {
+//				// 부서 정보가 없을 경우 기본값 사용
+//				departmentName = "-";
+//			}
+//		}
+//        model.addAttribute("departmentName", departmentName);
+//        
+//        // 주소록 정보 조회
+//        Directory directory = employeeDirectoryService.selectDirectoryByEmployeeNo(employeeNo);
+////        System.out.println("directory 정보 : " + directory);
+//        if(directory != null) {
+//        	DirectoryDto directoryDto = new DirectoryDto().toDto(directory);
+//        	model.addAttribute("directory", directoryDto);
+//        }
+//        
+//        
+//        // 연차 정보 조회
+//        AnnualLeave annualLeave = attendanceService.selectAnnualLeaveByEmployeeNo(employeeNo);
+//        AnnualLeaveDto annualLeaveDto;
+//        if (annualLeave != null) {
+//        	annualLeaveDto = new AnnualLeaveDto().toDto(annualLeave);
+//		}else {
+//			annualLeaveDto = new AnnualLeaveDto();
+//			annualLeaveDto.setAnnual_leave_total(0.0);
+//			annualLeaveDto.setAnnual_leave_used(0.0);
+//			annualLeaveDto.setAnnual_leave_remain(0.0);
+//		}
+//        model.addAttribute("annualLeave",annualLeaveDto);
+//        
+//		// 근태 기록이 있는 월 목록 조회
+//		List<String> monthList = attendanceService.selectAttendanceMonthList(employeeNo);
+//		
+//		// 현재 년월 가져오기
+//		String currentMonth = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy.MM"));
+//		
+//		// 현재 월이 목록에 포함되어 있다면 맨 위로 정렬
+//		if(monthList.contains(currentMonth)) {
+//			monthList.remove(currentMonth); // 중복 제거
+//			monthList.add(0, currentMonth); // 맨 앞에 삽입
+//		}
+//		
+//		model.addAttribute("monthList", monthList);
+//		
+//		// selectedMonth -> 사용자가 선택한 월이 없으면 현재 월이 기본값
+//		String selectedMonth = (month != null && !month.isEmpty()) ? month : currentMonth;
+//		model.addAttribute("selectedMonth",selectedMonth);
+//		// 해당 월의 근태 기록 조회
+//		List<AttendanceDto> attendanceList = attendanceService.selectAttendanceListByMonth(employeeNo, selectedMonth);
+//		model.addAttribute("attendanceList",attendanceList);
+//		
+//		// 근태 차트 요약 데이터
+//		Map<String, Object> chartData = attendanceService.getAttendanceChartData(employeeDetail);
+//		// 근무시간 문자열만 가져오기
+//		String totalWorkTime = (String) chartData.get("totalWorkTime");
+//		model.addAttribute("totalWorkTime", totalWorkTime);
+//		
+//		// 근태요약 정보 가져오기
+//		Map<String,Object> summaryData = attendanceService.getAttendanceChartData(employeeDetail);
+//		model.addAttribute("summaryData", summaryData);
+//		
+//		return "attendance/list";
+//	}
+//	
+//	@GetMapping("/chartData")
+//	@ResponseBody
+//	public Map<String,Object> getChartData(){
+//		// 현재 로그인 정보
+//		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+//		EmployeeDetails employeeDetail = (EmployeeDetails)authentication.getPrincipal();
+//		
+//		// 차트 데이터
+//		return attendanceService.getAttendanceChartData(employeeDetail);
+//		
+//	}
 	
 	
 }

--- a/eroom/src/main/java/com/eroom/attendance/repository/AnnualLeaveRepository.java
+++ b/eroom/src/main/java/com/eroom/attendance/repository/AnnualLeaveRepository.java
@@ -1,5 +1,7 @@
 package com.eroom.attendance.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.eroom.attendance.entity.AnnualLeave;
@@ -12,6 +14,7 @@ public interface AnnualLeaveRepository extends JpaRepository<AnnualLeave, Long> 
 	// 연차 정보 저장
 	AnnualLeave save(AnnualLeave annualLeave);
 
-
+	// 현재년도 연차 
+	AnnualLeave findByEmployee_EmployeeNoAndYear(Long employeeNo, Long year);
 
 }

--- a/eroom/src/main/java/com/eroom/attendance/scheduler/AnnualLeaveScheduler.java
+++ b/eroom/src/main/java/com/eroom/attendance/scheduler/AnnualLeaveScheduler.java
@@ -1,0 +1,41 @@
+package com.eroom.attendance.scheduler;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.eroom.attendance.service.AnnualLeaveService;
+import com.eroom.employee.entity.Employee;
+import com.eroom.employee.service.EmployeeService;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 연차 자동 부여 스케줄러 클래스
+ * 매년 1월1일 (테스트 날짜 5월12일 또는 13일) 에 모든 사원에게 연차 자동부여한다.	
+ */
+@Component
+@RequiredArgsConstructor
+public class AnnualLeaveScheduler {
+	
+	private final EmployeeService employeeService;
+	private final AnnualLeaveService annualLeaveService;
+	/**
+	 *  매년 1월 1일 00시에 실행 (테스트용 : 매일 자정으로 설정)
+	 */
+	@Scheduled(cron = "0 13 1 12 5 *", zone= "Asia/Seoul") // 테스트용 : 5월 12일 00시
+	public void generateAnnualLeaves() {
+		// 오늘 날짜 기준 연도
+		int yearInt = LocalDate.now().getYear();
+		Long year = Long.valueOf(yearInt);
+		// 전체 재직중 사원 목록
+		List<Employee> employeeList = employeeService.findAllEmployee();
+		
+		for(Employee employee : employeeList) {
+			// 연차 부여 서비스 호출
+			annualLeaveService.grantAnnualLeave(employee.getEmployeeNo(),year);
+		}
+	}
+}

--- a/eroom/src/main/java/com/eroom/attendance/service/AnnualLeaveService.java
+++ b/eroom/src/main/java/com/eroom/attendance/service/AnnualLeaveService.java
@@ -1,10 +1,14 @@
 package com.eroom.attendance.service;
 
+import java.time.LocalDate;
+
 import org.springframework.stereotype.Service;
 
 import com.eroom.attendance.dto.AnnualLeaveDto;
 import com.eroom.attendance.entity.AnnualLeave;
 import com.eroom.attendance.repository.AnnualLeaveRepository;
+import com.eroom.employee.entity.Employee;
+import com.eroom.employee.service.EmployeeService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,9 +16,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class AnnualLeaveService {
 	private final AnnualLeaveRepository annualLeaveRepository;
+	private final EmployeeService employeeService;
 
 	public AnnualLeave findByEmployeeNo(Long employeeNo) {
 		return annualLeaveRepository.findByEmployee_EmployeeNo(employeeNo);
+	}
+	// 현재년도 연차 정보 조회
+	public AnnualLeave selectAnnualLeaveByEmployeeNoAndYear(Long employeeNo, Long year) {
+		return annualLeaveRepository.findByEmployee_EmployeeNoAndYear(employeeNo,year);
 	}
 	
 	// 연차 정보 수정
@@ -33,4 +42,46 @@ public class AnnualLeaveService {
 		return null;
 	}
 	
+	// 연차 부여(매년 1월1일) 
+	public void grantAnnualLeave(Long employeeNo, Long year) {
+		// 사원 정보
+	    Employee employee = employeeService.findEmployeeByEmployeeNo(employeeNo);
+	    if (employee == null) return;	
+	    
+	    //  퇴사자 제외 처리
+	    if (employee.getEmployeeEndDate() != null) return;	    
+	    // 입사일 기준 1년 미만이면 연차 부여 제외
+	    LocalDate hireDate = employee.getEmployeeHireDate().toLocalDate();
+	    LocalDate referenceDate = LocalDate.of(year.intValue(), 5, 12); // 연차 부여 기준일
+	    					//	= LocalDate.of(year.intValue(), 1, 1); 
+	    if(hireDate.isAfter(referenceDate.minusYears(1))) return; // 입사일이 기준일 기준 1년 이내면 제외
+	    
+		// 기존 연차 정보가 있는지 확인
+		AnnualLeave existing = annualLeaveRepository.findByEmployee_EmployeeNoAndYear(employeeNo, year);
+		if(existing != null) {
+			return; // 이미 존재하는 경우 생략
+		}
+		
+		// 이전 연차 이월
+		Long prevYear = year -1;
+		AnnualLeave prevLeave = annualLeaveRepository.findByEmployee_EmployeeNoAndYear(employeeNo, prevYear);
+		double carryOver = 0.0;
+		if(prevLeave != null) {
+			// 총 연차 - 사용 연차 (선사용했을 경우 음수가 나올 수 있음)
+			carryOver = prevLeave.getAnnualLeaveTotal() - prevLeave.getAnnualLeaveUsed();
+		}
+		
+		// 연차 계산(기본 15일)
+		double total = 15.0 + carryOver;
+		
+		// 새로운 연차 생성
+		AnnualLeave newLeave = AnnualLeave.builder()
+							.employee(Employee.builder().employeeNo(employeeNo).build())
+							.year(year)
+							.annualLeaveTotal(total)
+							.annualLeaveUsed(0.0)
+							.build();
+		annualLeaveRepository.save(newLeave);
+		
+	}
 }

--- a/eroom/src/main/java/com/eroom/attendance/service/AttendanceService.java
+++ b/eroom/src/main/java/com/eroom/attendance/service/AttendanceService.java
@@ -125,28 +125,11 @@ public class AttendanceService {
 			}
 		}
 		
-
 		return resultMap;
 	}
 	
-	
-	// 근태 기록 전체 조회
-//	public List<Attendance> selectAttendanceList(){
-//		
-//		// 현재 로그인한 정보
-//		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-//		
-//		EmployeeDetails employeeDetail = (EmployeeDetails)authentication.getPrincipal();
-//		
-//		Long employeeNo = employeeDetail.getEmployee().getEmployeeNo(); 
-//		
-//		return attendanceRepository.findByEmployee_EmployeeNoOrderByAttendanceCheckInTimeDesc(employeeNo);
-//		
-//		
-//	}
 	// 연차 정보 조회
 	public AnnualLeave selectAnnualLeaveByEmployeeNo(Long employeeNo) {
-		
 		return annualLeaveRepository.findByEmployee_EmployeeNo(employeeNo);
 	}
 	
@@ -228,7 +211,6 @@ public class AttendanceService {
 //					(checkOut.getHour() - checkIn.getHour()) + ((checkOut.getMinute() - checkIn.getMinute()) / 60.0);
 			
 			workTimePerDay.put(checkIn.toLocalDate().toString(), workTime); // 날짜별 근무시간 저장
-
 			
 			// 요일별 근무시간 분류
 			// getDayOfWeek() -> 요일을 반환 -> toString() -> 요일을 문자열로 변환

--- a/eroom/src/main/java/com/eroom/common/AnnualPolicyUtil.java
+++ b/eroom/src/main/java/com/eroom/common/AnnualPolicyUtil.java
@@ -1,0 +1,18 @@
+package com.eroom.common;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class AnnualPolicyUtil {
+
+	// 연차 기준 연도 계산 -> 테스트용 5월 12일
+	public Long getTargetYearByPolicy() {
+		LocalDate now = LocalDate.now();
+		LocalDate grantDate = LocalDate.of(now.getYear(), 5, 12); // 연차 기준일
+						//	= LocalDate.of(now.getYear(), 1, 1);
+		// 1월 1일로 변경시 1 , 1 로 변경하면 됨
+		return now.isBefore(grantDate) ? (long)(now.getYear()-1) : (long)now.getYear();
+	}
+}

--- a/eroom/src/main/java/com/eroom/mypage/controller/MyPageController.java
+++ b/eroom/src/main/java/com/eroom/mypage/controller/MyPageController.java
@@ -24,7 +24,9 @@ import com.eroom.approval.service.ApprovalService;
 import com.eroom.attendance.dto.AnnualLeaveDto;
 import com.eroom.attendance.dto.AttendanceDto;
 import com.eroom.attendance.entity.AnnualLeave;
+import com.eroom.attendance.service.AnnualLeaveService;
 import com.eroom.attendance.service.AttendanceService;
+import com.eroom.common.AnnualPolicyUtil;
 import com.eroom.directory.dto.DirectoryDto;
 import com.eroom.directory.entity.Directory;
 import com.eroom.directory.service.DirectoryService;
@@ -41,8 +43,6 @@ import com.eroom.security.EmployeeDetails;
 
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import net.sf.dynamicreports.report.datasource.DRDataSource;
-import net.sf.jasperreports.engine.JRDataSource;
 
 @Controller
 @RequestMapping("/mypage")
@@ -56,6 +56,8 @@ public class MyPageController {
 	private final ProfileService profileService;
 	private final ApprovalService approvalService;
 	private final ReportService reportService;
+	private final AnnualLeaveService annualLeaveService;
+	private final AnnualPolicyUtil annualPolicyUtil;
 	
 	// 마이페이지
 	@GetMapping("/list")
@@ -95,9 +97,12 @@ public class MyPageController {
         	DirectoryDto directoryDto = new DirectoryDto().toDto(directory);
         	model.addAttribute("directory", directoryDto);
         }
-        
+        // 현재 년도
+		// Long currentYear = Long.valueOf(LocalDate.now().getYear());
+		// 기준일 기반 연차 연도 계산
+        Long targetYear = annualPolicyUtil.getTargetYearByPolicy();
         // 연차 정보 조회
-        AnnualLeave annualLeave = attendanceService.selectAnnualLeaveByEmployeeNo(employeeNo);
+        AnnualLeave annualLeave = annualLeaveService.selectAnnualLeaveByEmployeeNoAndYear(employee.getEmployeeNo(),targetYear);
         AnnualLeaveDto annualLeaveDto;
         if (annualLeave != null) {
         	annualLeaveDto = new AnnualLeaveDto().toDto(annualLeave);


### PR DESCRIPTION
	- 퇴사자 제외, 재직자 연차 15개 부여하는 스케줄러 생성.
	- 입사일 1년 이상 사원만 연차 부여 가능 -> 1년 미만 입사자는 월차 도입 예정
	- 테스트를 위해 5월12일자로 테스트 완료. 연차 부여 기준은 1월1일00시로 설정 예정
	- 전년도 연차 이월 가능 시스템으로 설계하여 전년도 잔여연차 + 이번년도 지급 연차 = 총 연차로 계산됨.